### PR TITLE
Fix drop_samples strategy for a pair of columns instead of full table when calculating score 

### DIFF
--- a/docs/modules/nominal.md
+++ b/docs/modules/nominal.md
@@ -54,7 +54,7 @@ continuous features using:
   
     * `cramer`: Cramer's V
       
-    * `theil`: Theil's U. When selected, heat-map rows are the provided information (meaning: $U = U(row|col)$)
+    * `theil`: Theil's U. When selected, heat-map rows are the provided information (meaning: $U = U(col|row)$)
   
 - **`num_num_assoc`** : `string`
     

--- a/dython/nominal.py
+++ b/dython/nominal.py
@@ -485,7 +485,7 @@ def compute_associations(dataset,
     nom_nom_assoc : string, default = 'cramer'
         Name of nominal-nominal (categorical-categorical) association to use.
         Options are 'cramer' for Cramer's V or 'theil' for Theil's U. If 'theil',
-        heat-map rows are the provided information (U = U(row|col)).
+        heat-map rows are the provided information (U = U(col|row)).
     num_num_assoc : string, default = 'pearson'
         Name of numerical-numerical association to use. Options are 'pearson'
         for Pearson's R, 'spearman' for Spearman's R, 'kendall' for Kendall's Tau.
@@ -565,7 +565,7 @@ def associations(dataset,
     nom_nom_assoc : string, default = 'cramer'
         Name of nominal-nominal (categorical-categorical) association to use.
         Options are 'cramer' for Cramer's V or `theil` for Theil's U. If 'theil',
-        heat-map rows are the provided information (U = U(row|col)).
+        heat-map rows are the provided information (U = U(col|row)).
     num_num_assoc : string, default = 'pearson'
         Name of numerical-numerical association to use. Options are 'pearson'
         for Pearson's R, 'spearman' for Spearman's R, 'kendall' for Kendall's Tau.


### PR DESCRIPTION
I think remove all nan row in full table can lead to lack of fully evaluating data. I suggest only removing nan values in a temporary dataframe consisting two columns during generating scores. Moreover, I added new check statement to avoid zero-size array.